### PR TITLE
Make audit recognise hed-only and devel-only in all taps

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -375,11 +375,11 @@ class FormulaAuditor
   end
 
   def audit_specs
-    if head_only?(formula) && formula.tap.downcase != "homebrew/homebrew-head-only"
+    if head_only?(formula) && formula.tap.downcase != "*/homebrew-head-only"
       problem "Head-only (no stable download)"
     end
 
-    if devel_only?(formula) && formula.tap.downcase != "homebrew/homebrew-devel-only"
+    if devel_only?(formula) && formula.tap.downcase != "*/homebrew-devel-only"
       problem "Devel-only (no stable download)"
     end
 


### PR DESCRIPTION
- add wildcard into expressions to identify head-only and dev-only taps